### PR TITLE
fix path names in tutorials

### DIFF
--- a/tutorials/nlp_attribution.ipynb
+++ b/tutorials/nlp_attribution.ipynb
@@ -40,7 +40,7 @@
     "\n",
     "1. All the required packages are installed.\n",
     "\n",
-    "2. Pretrained weight `path/to/informationbottleneck/pretrained/deep_lstm.pt`\n",
+    "2. Pretrained weight `path/to/InputIBA/pretrained/deep_lstm.pt`\n",
     " exists."
    ]
   },
@@ -72,7 +72,7 @@
     "id": "4qF0VCBPN8z7"
    },
    "source": [
-    "Change the working directory to `path/to/informationbottleneck/`, modify\n",
+    "Change the working directory to `path/to/InputIBA/`, modify\n",
     "this if necessary."
    ]
   },
@@ -82,9 +82,10 @@
     "id": "kHbEVbHROTXY"
    },
    "source": [
-    "# cwd switch from `informationbottleneck/tutorials/` to\n",
-    "# `informationbottleneck/`\n",
+    "# cwd switch from `InputIBA/tutorials/` to\n",
+    "# `InputIBA/`\n",
     "os.chdir('..')\n",
+    "print(f'Current working directory: {os.getcwd()}')\n",
     "cfg_path = 'configs/deep_lstm.py'"
    ],
    "execution_count": 2,
@@ -201,7 +202,7 @@
     "id": "HzXYciFx0tPf"
    },
    "source": [
-    "from iba.datasets import nlp_collate_fn\n",
+    "from input_iba.datasets import nlp_collate_fn\n",
     "dataloader = DataLoader(dataset,\n",
     "                        collate_fn=nlp_collate_fn,\n",
     "                        **cfg.data['data_loader'])"

--- a/tutorials/vision_attribution.ipynb
+++ b/tutorials/vision_attribution.ipynb
@@ -15,7 +15,7 @@
     "1. All the required packages are installed\n",
     "\n",
     "2. A small subset of Imagenet is downloaded and linked to\n",
-    "`path/to/informationbottleneck/data/imagenet`. A pre-processed ImageNet\n",
+    "`path/to/InputIBA/data/imagenet`. A pre-processed ImageNet\n",
     "(containing images and bounding boxes) can be downloaded from\n",
     "[this link](https://drive.google.com/file/d/1LBKQ4BR3zepfnQAKCumkABHYjXBanBBL/view?usp=sharing)"
    ]
@@ -44,7 +44,7 @@
   {
    "cell_type": "markdown",
    "source": [
-    "Change current working directory to `path/to/informationbottleneck`. Modify\n",
+    "Change current working directory to `path/to/InputIBA`. Modify\n",
     "this if necessary."
    ],
    "metadata": {
@@ -60,6 +60,7 @@
    "outputs": [],
    "source": [
     "os.chdir('..')\n",
+    "print(f'Current working directory: {os.getcwd()}')\n",
     "cfg = mmcv.Config.fromfile('configs/vgg_imagenet.py')\n",
     "device = 'cuda:0'"
    ],


### PR DESCRIPTION
The tutorials were still using `informationbottelneck` as path name for the project. Since this project has been renamed to `InputIBA`, we update the path name in the tutorials via this PR.